### PR TITLE
[Issue-5] Add public init method

### DIFF
--- a/Sources/YAnalytics/Implementations/MockAnalyticsEngine.swift
+++ b/Sources/YAnalytics/Implementations/MockAnalyticsEngine.swift
@@ -22,6 +22,9 @@ final public class MockAnalyticsEngine {
     public private(set) var userProperties: [String: String] = [:]
     /// Dictionary of event metadata tracked in `.event` events
     public private(set) var events: [String: Metadata?] = [:]
+
+    /// Initialize mock analytics engine
+    public init() { }
 }
 
 // MARK: - AnalyticsEngine


### PR DESCRIPTION
## Introduction ##

When we published `MockAnalyticsEngine` although the class is `public`, we did not provide a `public` initializer which makes it impossible to allocate an instance of the class.

## Purpose ##

Fix #5 
Add a public initializer.

## Scope ##

* Simple change to `MockAnalyticsEngine`

## 📈 Coverage ##

##### Code #####

100%
<img width="563" alt="image" src="https://user-images.githubusercontent.com/1037520/221611375-42a80fc6-d598-4fd4-997e-4be89171440d.png">

##### Documentation #####

<img width="380" alt="image" src="https://user-images.githubusercontent.com/1037520/221611478-096cb9a0-c31a-453d-9429-1defd0d45ab3.png">
