### PR TITLE
[Issue-7] Add Event Factory

### DIFF
--- a/Sources/YAnalytics/Protocol/AnalyticsEngine.swift
+++ b/Sources/YAnalytics/Protocol/AnalyticsEngine.swift
@@ -13,4 +13,19 @@ public protocol AnalyticsEngine {
     /// Track an analytics event
     /// - Parameter event: the event to log
     func track(event: AnalyticsEvent)
+
+    /// Tracks an analytics event
+    /// - Parameter factory: object that generates the event to log
+    func track(event factory: AnalyticsEventFactory)
+}
+
+/// Default implementation of `track(factory:)`
+extension AnalyticsEngine {
+    /// Tracks an analytics event.
+    ///
+    /// Extracts the event from the factory and tracks that.
+    /// - Parameter factory: object that generates the event to log
+    public func track(event factory: AnalyticsEventFactory) {
+        track(event: factory.event)
+    }
 }

--- a/Sources/YAnalytics/Protocol/AnalyticsEventFactory.swift
+++ b/Sources/YAnalytics/Protocol/AnalyticsEventFactory.swift
@@ -1,0 +1,18 @@
+//
+//  AnalyticsEventFactory.swift
+//  YAnalytics
+//
+//  Created by Mark Pospesel on 3/8/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import Foundation
+
+/// Anything that generates an analytics event.
+///
+/// Three protocols, `ScreenViewFactory`, `UserPropertyFactory`, and `EventFactory`, conform to `AnalyticsEventFactory`;
+/// one for each of the three cases in the `AnalyticsEvent` enum.
+public protocol AnalyticsEventFactory {
+    /// The event
+    var event: AnalyticsEvent { get }
+}

--- a/Sources/YAnalytics/Protocol/EventFactory.swift
+++ b/Sources/YAnalytics/Protocol/EventFactory.swift
@@ -1,0 +1,25 @@
+//
+//  EventFactory.swift
+//  YAnalytics
+//
+//  Created by Mark Pospesel on 3/8/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import Foundation
+
+/// Anything that generates an analytics event of type `AnalyticsEvent.event`
+public protocol EventFactory: AnalyticsEventFactory {
+    /// Event name
+    var name: String { get }
+    /// Event parameters
+    var parameters: Metadata? { get }
+}
+
+/// Default implementation of `event` property
+public extension EventFactory {
+    /// Generates an event (of type `.event`) from `name` and `parameters`
+    var event: AnalyticsEvent {
+        .event(name: name, parameters: parameters)
+    }
+}

--- a/Sources/YAnalytics/Protocol/ScreenViewFactory.swift
+++ b/Sources/YAnalytics/Protocol/ScreenViewFactory.swift
@@ -1,0 +1,29 @@
+//
+//  ScreenViewFactory.swift
+//  YAnalytics
+//
+//  Created by Mark Pospesel on 3/8/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import Foundation
+
+/// Anything that generates an analytics event of type `AnalyticsEvent.screenView`
+public protocol ScreenViewFactory: AnalyticsEventFactory {
+    /// Screen name
+    var screenName: String { get }
+}
+
+/// Default implementation of `event` property
+public extension ScreenViewFactory {
+    /// Generates an event (of type `.screenView`) from `screenName`
+    var event: AnalyticsEvent {
+        .screenView(screenName: screenName)
+    }
+}
+
+/// RawRepresentable (e.g. all string-based enums) conforms to ScreenViewFactory by simply returning its raw value
+extension RawRepresentable where RawValue == String {
+    /// URL path string
+    public var screenName: String { rawValue }
+}

--- a/Sources/YAnalytics/Protocol/UserPropertyFactory.swift
+++ b/Sources/YAnalytics/Protocol/UserPropertyFactory.swift
@@ -1,0 +1,25 @@
+//
+//  UserPropertyFactory.swift
+//  YAnalytics
+//
+//  Created by Mark Pospesel on 3/8/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import Foundation
+
+/// Anything that generates an analytics event of type `AnalyticsEvent.userProperty`
+public protocol UserPropertyFactory: AnalyticsEventFactory {
+    /// Property name
+    var name: String { get }
+    /// Property value
+    var value: String { get }
+}
+
+/// Default implementation of `event` property
+public extension UserPropertyFactory {
+    /// Generates an event (of type `.userProperty`) from `name` and `value`
+    var event: AnalyticsEvent {
+        .userProperty(name: name, value: value)
+    }
+}

--- a/Tests/YAnalyticsTests/Protocols/AnalyticsEngineTests.swift
+++ b/Tests/YAnalyticsTests/Protocols/AnalyticsEngineTests.swift
@@ -1,0 +1,34 @@
+//
+//  AnalyticsEngineTests.swift
+//  YAnalytics
+//
+//  Created by Mark Pospesel on 3/8/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import XCTest
+@testable import YAnalytics
+
+final class AnalyticsEngineTests: XCTestCase {
+    func test_trackFactory_tracksEvents() {
+        // Given
+        let engine = MockAnalyticsEngine()
+
+        // When
+        MockEvent.allCases.forEach {
+            engine.track(event: $0)
+        }
+
+        // Then
+        XCTAssertEqual(engine.allEvents.count, 3)
+        XCTAssertEqual(engine.screenViews.joined(), "abcdefxyz")
+    }
+}
+
+private extension AnalyticsEngineTests {
+    enum MockEvent: String, CaseIterable, ScreenViewFactory {
+        case abc
+        case def
+        case xyz
+    }
+}

--- a/Tests/YAnalyticsTests/Protocols/EventFactoryTests.swift
+++ b/Tests/YAnalyticsTests/Protocols/EventFactoryTests.swift
@@ -1,0 +1,41 @@
+//
+//  EventFactoryTests.swift
+//  YAnalytics
+//
+//  Created by Mark Pospesel on 3/8/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import XCTest
+@testable import YAnalytics
+
+final class EventFactoryTests: XCTestCase {
+    func test_event_deliversEvent() throws {
+        try MockEvent.allCases.forEach {
+            switch $0.event {
+            case .event(let name, let parameters):
+                XCTAssertEqual(name, $0.name)
+                let parameters = try XCTUnwrap(parameters as? [String: String])
+                let expected = try XCTUnwrap($0.parameters as? [String: String])
+                XCTAssertEqual(parameters, expected)
+            default:
+                XCTFail("Unexpected event type: \($0.event)")
+            }
+        }
+    }
+}
+
+private extension EventFactoryTests {
+    enum MockEvent: String, EventFactory, CaseIterable {
+        case abc
+        case def
+
+        var name: String { rawValue }
+        var parameters: Metadata? {
+            [
+                "value": "42\(rawValue.uppercased())",
+                "type": "dictionary"
+            ]
+        }
+    }
+}

--- a/Tests/YAnalyticsTests/Protocols/ScreenViewFactoryTests.swift
+++ b/Tests/YAnalyticsTests/Protocols/ScreenViewFactoryTests.swift
@@ -1,0 +1,31 @@
+//
+//  ScreenViewFactoryTests.swift
+//  YAnalytics
+//
+//  Created by Mark Pospesel on 3/8/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import XCTest
+@testable import YAnalytics
+
+final class ScreenViewFactoryTests: XCTestCase {
+    func test_event_deliversEvent() {
+        MockScreenView.allCases.forEach {
+            switch $0.event {
+            case .screenView(let screenName):
+                XCTAssertEqual(screenName, $0.screenName)
+                XCTAssertEqual(screenName, $0.rawValue)
+            default:
+                XCTFail("Unexpected event type: \($0.event)")
+            }
+        }
+    }
+}
+
+private extension ScreenViewFactoryTests {
+    enum MockScreenView: String, ScreenViewFactory, CaseIterable {
+        case abc
+        case def
+    }
+}

--- a/Tests/YAnalyticsTests/Protocols/UserPropertyFactoryTests.swift
+++ b/Tests/YAnalyticsTests/Protocols/UserPropertyFactoryTests.swift
@@ -1,0 +1,35 @@
+//
+//  UserPropertyFactoryTests.swift
+//  YAnalytics
+//
+//  Created by Mark Pospesel on 3/8/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import XCTest
+@testable import YAnalytics
+
+final class UserPropertyFactoryTests: XCTestCase {
+    func test_event_deliversEvent() {
+        MockUserProperty.allCases.forEach {
+            switch $0.event {
+            case .userProperty(let name, let value):
+                XCTAssertEqual(name, $0.name)
+                XCTAssertEqual(value, $0.value)
+                XCTAssertEqual(value, $0.name.capitalized)
+            default:
+                XCTFail("Unexpected event type: \($0.event)")
+            }
+        }
+    }
+}
+
+private extension UserPropertyFactoryTests {
+    enum MockUserProperty: String, UserPropertyFactory, CaseIterable {
+        case abc
+        case def
+
+        var name: String { rawValue }
+        var value: String { rawValue.capitalized }
+    }
+}


### PR DESCRIPTION
## Introduction ##

We could make it easier to define and track events if we supported tracking both events (we have) and _anything that can be converted to an event_ (subject of this PR). I realized that this would be valuable when creating examples of how to set up YAnalytics in our upcoming YTemplate repo.

## Purpose ##

Add a protocol for anything that can generate an event and a `track()` override to `AnalyticsEngine` that accepts it.
Fix #7 

## Scope ##
* Add new protocols
* Extend `AnalyticsEngine` with a track override that accepts an event factory
* Add unit tests

## Discussion ##

Original ticket was just to add a protocol that corresponded to `AnalyticsEvent.event` (arguably the most common type of event to track), but decided we should have protocols for each of the three events we support plus a more generic protocol that is not tied to any single type of event. (Granted the naming is a bit weird because AnalyticsEvent has a case named `.event`)

## 📈 Coverage ##

##### Code #####

100%

<img width="603" alt="image" src="https://user-images.githubusercontent.com/1037520/223776568-dc9f74f1-4099-4b81-9e58-15c8d4d8b4f2.png">

##### Documentation #####

100%

<img width="592" alt="image" src="https://user-images.githubusercontent.com/1037520/223776904-45f54749-03cd-4719-a50b-3c1adc86286c.png">
